### PR TITLE
Extended runCMSSWtest.sh by 2017 data sample

### DIFF
--- a/processors/ttX3.py
+++ b/processors/ttX3.py
@@ -179,7 +179,11 @@ def jetSelection(jetDict):
             )
         ])
         
-        
+        if isMC:
+	    truthKeys = ['hadronFlavour','partonFlavour']
+        else:
+            truthKeys = [] 
+
         seq.append(
             BTagSelection(
                 inputCollection=lambda event,sys=systName: getattr(event,"selectedJets_"+sys),
@@ -189,7 +193,7 @@ def jetSelection(jetDict):
                 jetMaxEta=2.4,
                 workingpoint = BTagSelection.TIGHT,
                 storeKinematics=[],
-                storeTruthKeys = ['hadronFlavour','partonFlavour'],
+                storeTruthKeys = truthKeys,
             )
         )
         

--- a/test/runCMSSWTest.sh
+++ b/test/runCMSSWTest.sh
@@ -20,7 +20,7 @@ function run_test()
 
 
     echo "==================== data ==============="
-    python PhysicsTools/NanoAODTools/processors/ttX3.py --year 2017 --isData --input=https://github.com/ttXcubed/test-files/raw/main/nanoAODv9UL/TTTo2L2Nu_HT500Njet7_TuneCP5_13TeV-powheg-pythia8_2017.root . || return 1
+    python PhysicsTools/NanoAODTools/processors/ttX3.py --year 2017 --isData --input=https://github.com/ttXcubed/test-files/raw/main/nanoAODv9UL_data/MuonEG_Run2017B.root . || return 1
 
     
     echo "==================== done ====================="


### PR DESCRIPTION
For the test run of ttx3.py using the `--isData` flag, the 2017 MuonEG Run2017B file (containing 10k events) will be used